### PR TITLE
Fix the missing includes and extern function forward declarations

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,177 +1,177 @@
 Installation Instructions
 *************************
 
-   Copyright (C) 1994-1996, 1999-2002, 2004-2016 Free Software
-Foundation, Inc.
-
-   Copying and distribution of this file, with or without modification,
-are permitted in any medium without royalty provided the copyright
-notice and this notice are preserved.  This file is offered as-is,
-without warranty of any kind.
-
 Basic Installation
 ==================
 
-   Briefly, the shell command './configure && make && make install'
-should configure, build, and install this package.  The following
-more-detailed instructions are generic; see the 'README' file for
-instructions specific to this package.  Some packages provide this
-'INSTALL' file but do not implement all of the features documented
-below.  The lack of an optional feature in a given package is not
-necessarily a bug.  More recommendations for GNU packages can be found
-in *note Makefile Conventions: (standards)Makefile Conventions.
+   The following shell commands:
 
-   The 'configure' shell script attempts to guess correct values for
+     test -f configure || ./bootstrap
+     ./configure
+     make
+     make install
+
+should configure, build, and install this package.  The first line,
+which bootstraps, is intended for developers; when building from
+distribution tarballs it does nothing and can be skipped.
+
+   The following more-detailed instructions are generic; see the
+‘README’ file for instructions specific to this package.  Some packages
+provide this ‘INSTALL’ file but do not implement all of the features
+documented below.  The lack of an optional feature in a given package is
+not necessarily a bug.  More recommendations for GNU packages can be
+found in the GNU Coding Standards.
+
+   Many packages have scripts meant for developers instead of ordinary
+builders, as they may use developer tools that are less commonly
+installed, or they may access the network, which has privacy
+implications.  If the ‘bootstrap’ shell script exists, it attempts to
+build the ‘configure’ shell script and related files, possibly using
+developer tools or the network.  Because the output of ‘bootstrap’ is
+system-independent, it is normally run by a package developer so that
+its output can be put into the distribution tarball and ordinary
+builders and users need not run ‘bootstrap’.  Some packages have
+commands like ‘./autopull.sh’ and ‘./autogen.sh’ that you can run
+instead of ‘./bootstrap’, for more fine-grained control over
+bootstrapping.
+
+   The ‘configure’ shell script attempts to guess correct values for
 various system-dependent variables used during compilation.  It uses
-those values to create a 'Makefile' in each directory of the package.
-It may also create one or more '.h' files containing system-dependent
-definitions.  Finally, it creates a shell script 'config.status' that
+those values to create a ‘Makefile’ in each directory of the package.
+It may also create one or more ‘.h’ files containing system-dependent
+definitions.  Finally, it creates a shell script ‘config.status’ that
 you can run in the future to recreate the current configuration, and a
-file 'config.log' containing compiler output (useful mainly for
-debugging 'configure').
+file ‘config.log’ containing output useful for debugging ‘configure’.
 
-   It can also use an optional file (typically called 'config.cache' and
-enabled with '--cache-file=config.cache' or simply '-C') that saves the
+   It can also use an optional file (typically called ‘config.cache’ and
+enabled with ‘--cache-file=config.cache’ or simply ‘-C’) that saves the
 results of its tests to speed up reconfiguring.  Caching is disabled by
 default to prevent problems with accidental use of stale cache files.
 
    If you need to do unusual things to compile the package, please try
-to figure out how 'configure' could check whether to do them, and mail
-diffs or instructions to the address given in the 'README' so they can
+to figure out how ‘configure’ could check whether to do them, and mail
+diffs or instructions to the address given in the ‘README’ so they can
 be considered for the next release.  If you are using the cache, and at
-some point 'config.cache' contains results you don't want to keep, you
+some point ‘config.cache’ contains results you don’t want to keep, you
 may remove or edit it.
 
-   The file 'configure.ac' (or 'configure.in') is used to create
-'configure' by a program called 'autoconf'.  You need 'configure.ac' if
-you want to change it or regenerate 'configure' using a newer version of
-'autoconf'.
+   The ‘autoconf’ program generates ‘configure’ from the file
+‘configure.ac’.  Normally you should edit ‘configure.ac’ instead of
+editing ‘configure’ directly.
 
    The simplest way to compile this package is:
 
-  1. 'cd' to the directory containing the package's source code and type
-     './configure' to configure the package for your system.
+  1. ‘cd’ to the directory containing the package’s source code.
 
-     Running 'configure' might take a while.  While running, it prints
-     some messages telling which features it is checking for.
+  2. If this is a developer checkout and file ‘configure’ does not yet
+     exist, type ‘./bootstrap’ to create it.  You may need special
+     developer tools and network access to bootstrap, and the network
+     access may have privacy implications.
 
-  2. Type 'make' to compile the package.
+  3. Type ‘./configure’ to configure the package for your system.  This
+     might take a while.  While running, ‘configure’ prints messages
+     telling which features it is checking for.
 
-  3. Optionally, type 'make check' to run any self-tests that come with
+  4. Type ‘make’ to compile the package.
+
+  5. Optionally, type ‘make check’ to run any self-tests that come with
      the package, generally using the just-built uninstalled binaries.
 
-  4. Type 'make install' to install the programs and any data files and
+  6. Type ‘make install’ to install the programs and any data files and
      documentation.  When installing into a prefix owned by root, it is
      recommended that the package be configured and built as a regular
-     user, and only the 'make install' phase executed with root
+     user, and only the ‘make install’ phase executed with root
      privileges.
 
-  5. Optionally, type 'make installcheck' to repeat any self-tests, but
+  7. Optionally, type ‘make installcheck’ to repeat any self-tests, but
      this time using the binaries in their final installed location.
      This target does not install anything.  Running this target as a
-     regular user, particularly if the prior 'make install' required
+     regular user, particularly if the prior ‘make install’ required
      root privileges, verifies that the installation completed
      correctly.
 
-  6. You can remove the program binaries and object files from the
-     source code directory by typing 'make clean'.  To also remove the
-     files that 'configure' created (so you can compile the package for
-     a different kind of computer), type 'make distclean'.  There is
-     also a 'make maintainer-clean' target, but that is intended mainly
-     for the package's developers.  If you use it, you may have to get
-     all sorts of other programs in order to regenerate files that came
-     with the distribution.
+  8. You can remove the program binaries and object files from the
+     source code directory by typing ‘make clean’.  To also remove the
+     files that ‘configure’ created (so you can compile the package for
+     a different kind of computer), type ‘make distclean’.  There is
+     also a ‘make maintainer-clean’ target, but that is intended mainly
+     for the package’s developers.  If you use it, you may have to
+     bootstrap again.
 
-  7. Often, you can also type 'make uninstall' to remove the installed
-     files again.  In practice, not all packages have tested that
-     uninstallation works correctly, even though it is required by the
-     GNU Coding Standards.
-
-  8. Some packages, particularly those that use Automake, provide 'make
-     distcheck', which can by used by developers to test that all other
-     targets like 'make install' and 'make uninstall' work correctly.
-     This target is generally not run by end users.
+  9. If the package follows the GNU Coding Standards, you can type ‘make
+     uninstall’ to remove the installed files.
 
 Compilers and Options
 =====================
 
    Some systems require unusual options for compilation or linking that
-the 'configure' script does not know about.  Run './configure --help'
+the ‘configure’ script does not know about.  Run ‘./configure --help’
 for details on some of the pertinent environment variables.
 
-   You can give 'configure' initial values for configuration parameters
+   You can give ‘configure’ initial values for configuration parameters
 by setting variables in the command line or in the environment.  Here is
 an example:
 
-     ./configure CC=c99 CFLAGS=-g LIBS=-lposix
+     ./configure CC=gcc CFLAGS=-g LIBS=-lposix
 
-   *Note Defining Variables::, for more details.
+   See “Defining Variables” for more details.
 
 Compiling For Multiple Architectures
 ====================================
 
    You can compile the package for more than one kind of computer at the
-same time, by placing the object files for each architecture in their
-own directory.  To do this, you can use GNU 'make'.  'cd' to the
-directory where you want the object files and executables to go and run
-the 'configure' script.  'configure' automatically checks for the source
-code in the directory that 'configure' is in and in '..'.  This is known
-as a "VPATH" build.
+same time, by placing the object files for each system in their own
+directory.  To do this, you can use GNU ‘make’.  ‘cd’ to the directory
+where you want the object files and executables to go and run the
+‘configure’ script.  ‘configure’ automatically checks for the source
+code in the directory that ‘configure’ is in and in ‘..’.  This is known
+as a “VPATH” build.
 
-   With a non-GNU 'make', it is safer to compile the package for one
-architecture at a time in the source code directory.  After you have
-installed the package for one architecture, use 'make distclean' before
-reconfiguring for another architecture.
+   With a non-GNU ‘make’, it is safer to compile the package for one
+system at a time in the source code directory.  After you have installed
+the package for one system, use ‘make distclean’ before reconfiguring
+for another system.
 
-   On MacOS X 10.5 and later systems, you can create libraries and
-executables that work on multiple system types--known as "fat" or
-"universal" binaries--by specifying multiple '-arch' options to the
-compiler but only a single '-arch' option to the preprocessor.  Like
-this:
-
-     ./configure CC="gcc -arch i386 -arch x86_64 -arch ppc -arch ppc64" \
-                 CXX="g++ -arch i386 -arch x86_64 -arch ppc -arch ppc64" \
-                 CPP="gcc -E" CXXCPP="g++ -E"
-
-   This is not guaranteed to produce working output in all cases, you
-may have to build one architecture at a time and combine the results
-using the 'lipo' tool if you have problems.
+   Some platforms, notably macOS, support “fat” or “universal” binaries,
+where a single binary can execute on different architectures.  On these
+platforms you can configure and compile just once, with options specific
+to that platform.
 
 Installation Names
 ==================
 
-   By default, 'make install' installs the package's commands under
-'/usr/local/bin', include files under '/usr/local/include', etc.  You
-can specify an installation prefix other than '/usr/local' by giving
-'configure' the option '--prefix=PREFIX', where PREFIX must be an
+   By default, ‘make install’ installs the package’s commands under
+‘/usr/local/bin’, include files under ‘/usr/local/include’, etc.  You
+can specify an installation prefix other than ‘/usr/local’ by giving
+‘configure’ the option ‘--prefix=PREFIX’, where PREFIX must be an
 absolute file name.
 
    You can specify separate installation prefixes for
 architecture-specific files and architecture-independent files.  If you
-pass the option '--exec-prefix=PREFIX' to 'configure', the package uses
+pass the option ‘--exec-prefix=PREFIX’ to ‘configure’, the package uses
 PREFIX as the prefix for installing programs and libraries.
 Documentation and other data files still use the regular prefix.
 
    In addition, if you use an unusual directory layout you can give
-options like '--bindir=DIR' to specify different values for particular
-kinds of files.  Run 'configure --help' for a list of the directories
+options like ‘--bindir=DIR’ to specify different values for particular
+kinds of files.  Run ‘configure --help’ for a list of the directories
 you can set and what kinds of files go in them.  In general, the default
-for these options is expressed in terms of '${prefix}', so that
-specifying just '--prefix' will affect all of the other directory
+for these options is expressed in terms of ‘${prefix}’, so that
+specifying just ‘--prefix’ will affect all of the other directory
 specifications that were not explicitly provided.
 
    The most portable way to affect installation locations is to pass the
-correct locations to 'configure'; however, many packages provide one or
+correct locations to ‘configure’; however, many packages provide one or
 both of the following shortcuts of passing variable assignments to the
-'make install' command line to change installation locations without
+‘make install’ command line to change installation locations without
 having to reconfigure or recompile.
 
    The first method involves providing an override variable for each
-affected directory.  For example, 'make install
-prefix=/alternate/directory' will choose an alternate location for all
+affected directory.  For example, ‘make install
+prefix=/alternate/directory’ will choose an alternate location for all
 directory configuration variables that were expressed in terms of
-'${prefix}'.  Any directories that were specified during 'configure',
-but not in terms of '${prefix}', must each be overridden at install time
+‘${prefix}’.  Any directories that were specified during ‘configure’,
+but not in terms of ‘${prefix}’, must each be overridden at install time
 for the entire installation to be relocated.  The approach of makefile
 variable overrides for each directory variable is required by the GNU
 Coding Standards, and ideally causes no recompilation.  However, some
@@ -179,190 +179,187 @@ platforms have known limitations with the semantics of shared libraries
 that end up requiring recompilation when using this method, particularly
 noticeable in packages that use GNU Libtool.
 
-   The second method involves providing the 'DESTDIR' variable.  For
-example, 'make install DESTDIR=/alternate/directory' will prepend
-'/alternate/directory' before all installation names.  The approach of
-'DESTDIR' overrides is not required by the GNU Coding Standards, and
+   The second method involves providing the ‘DESTDIR’ variable.  For
+example, ‘make install DESTDIR=/alternate/directory’ will prepend
+‘/alternate/directory’ before all installation names.  The approach of
+‘DESTDIR’ overrides is not required by the GNU Coding Standards, and
 does not work on platforms that have drive letters.  On the other hand,
 it does better at avoiding recompilation issues, and works well even
-when some directory options were not specified in terms of '${prefix}'
-at 'configure' time.
+when some directory options were not specified in terms of ‘${prefix}’
+at ‘configure’ time.
 
 Optional Features
 =================
 
    If the package supports it, you can cause programs to be installed
-with an extra prefix or suffix on their names by giving 'configure' the
-option '--program-prefix=PREFIX' or '--program-suffix=SUFFIX'.
+with an extra prefix or suffix on their names by giving ‘configure’ the
+option ‘--program-prefix=PREFIX’ or ‘--program-suffix=SUFFIX’.
 
-   Some packages pay attention to '--enable-FEATURE' options to
-'configure', where FEATURE indicates an optional part of the package.
-They may also pay attention to '--with-PACKAGE' options, where PACKAGE
-is something like 'gnu-as' or 'x' (for the X Window System).  The
-'README' should mention any '--enable-' and '--with-' options that the
-package recognizes.
-
-   For packages that use the X Window System, 'configure' can usually
-find the X include and library files automatically, but if it doesn't,
-you can use the 'configure' options '--x-includes=DIR' and
-'--x-libraries=DIR' to specify their locations.
+   Some packages pay attention to ‘--enable-FEATURE’ and
+‘--disable-FEATURE’ options to ‘configure’, where FEATURE indicates an
+optional part of the package.  They may also pay attention to
+‘--with-PACKAGE’ and ‘--without-PACKAGE’ options, where PACKAGE is
+something like ‘gnu-ld’.  ‘./configure --help’ should mention the
+‘--enable-...’ and ‘--with-...’ options that the package recognizes.
 
    Some packages offer the ability to configure how verbose the
-execution of 'make' will be.  For these packages, running './configure
---enable-silent-rules' sets the default to minimal output, which can be
-overridden with 'make V=1'; while running './configure
---disable-silent-rules' sets the default to verbose, which can be
-overridden with 'make V=0'.
+execution of ‘make’ will be.  For these packages, running ‘./configure
+--enable-silent-rules’ sets the default to minimal output, which can be
+overridden with ‘make V=1’; while running ‘./configure
+--disable-silent-rules’ sets the default to verbose, which can be
+overridden with ‘make V=0’.
 
-Particular systems
-==================
+Specifying a System Type
+========================
 
-   On HP-UX, the default C compiler is not ANSI C compatible.  If GNU CC
-is not installed, it is recommended to use the following options in
-order to use an ANSI C compiler:
+   By default ‘configure’ builds for the current system.  To create
+binaries that can run on a different system type, specify a
+‘--host=TYPE’ option along with compiler variables that specify how to
+generate object code for TYPE.  For example, to create binaries intended
+to run on a 64-bit ARM processor:
 
-     ./configure CC="cc -Ae -D_XOPEN_SOURCE=500"
+     ./configure --host=aarch64-linux-gnu \
+        CC=aarch64-linux-gnu-gcc \
+        CXX=aarch64-linux-gnu-g++
 
-and if that doesn't work, install pre-built binaries of GCC for HP-UX.
+If done on a machine that can execute these binaries (e.g., via
+‘qemu-aarch64’, ‘$QEMU_LD_PREFIX’, and Linux’s ‘binfmt_misc’
+capability), the build behaves like a native build.  Otherwise it is a
+cross-build: ‘configure’ will make cross-compilation guesses instead of
+running test programs, and ‘make check’ will not work.
 
-   HP-UX 'make' updates targets which have the same time stamps as their
-prerequisites, which makes it generally unusable when shipped generated
-files such as 'configure' are involved.  Use GNU 'make' instead.
+   A system type can either be a short name like ‘mingw64’, or a
+canonical name like ‘x86_64-pc-linux-gnu’.  Canonical names have the
+form CPU-COMPANY-SYSTEM where SYSTEM is either OS or KERNEL-OS.  To
+canonicalize and validate a system type, you can run the command
+‘config.sub’, which is often squirreled away in a subdirectory like
+‘build-aux’.  For example:
 
-   On OSF/1 a.k.a. Tru64, some versions of the default C compiler cannot
-parse its '<wchar.h>' header file.  The option '-nodtk' can be used as a
-workaround.  If GNU CC is not installed, it is therefore recommended to
-try
+     $ build-aux/config.sub arm64-linux
+     aarch64-unknown-linux-gnu
+     $ build-aux/config.sub riscv-lnx
+     Invalid configuration 'riscv-lnx': OS 'lnx' not recognized
 
-     ./configure CC="cc"
+You can look at the ‘config.sub’ file to see which types are recognized.
+If the file is absent, this package does not need the system type.
 
-and if that doesn't work, try
+   If ‘configure’ fails with the diagnostic “cannot guess build type”.
+‘config.sub’ did not recognize your system’s type.  In this case, first
+fetch the newest versions of these files from the GNU config package
+(https://savannah.gnu.org/projects/config).  If that fixes things,
+please report it to the maintainers of the package containing
+‘configure’.  Otherwise, you can try the configure option ‘--build=TYPE’
+where TYPE comes close to your system type; also, please report the
+problem to <config-patches@gnu.org>.
 
-     ./configure CC="cc -nodtk"
-
-   On Solaris, don't put '/usr/ucb' early in your 'PATH'.  This
-directory contains several dysfunctional programs; working variants of
-these programs are available in '/usr/bin'.  So, if you need '/usr/ucb'
-in your 'PATH', put it _after_ '/usr/bin'.
-
-   On Haiku, software installed for all users goes in '/boot/common',
-not '/usr/local'.  It is recommended to use the following options:
-
-     ./configure --prefix=/boot/common
-
-Specifying the System Type
-==========================
-
-   There may be some features 'configure' cannot figure out
-automatically, but needs to determine by the type of machine the package
-will run on.  Usually, assuming the package is built to be run on the
-_same_ architectures, 'configure' can figure that out, but if it prints
-a message saying it cannot guess the machine type, give it the
-'--build=TYPE' option.  TYPE can either be a short name for the system
-type, such as 'sun4', or a canonical name which has the form:
-
-     CPU-COMPANY-SYSTEM
-
-where SYSTEM can have one of these forms:
-
-     OS
-     KERNEL-OS
-
-   See the file 'config.sub' for the possible values of each field.  If
-'config.sub' isn't included in this package, then this package doesn't
-need to know the machine type.
-
-   If you are _building_ compiler tools for cross-compiling, you should
-use the option '--target=TYPE' to select the type of system they will
-produce code for.
-
-   If you want to _use_ a cross compiler, that generates code for a
-platform different from the build platform, you should specify the
-"host" platform (i.e., that on which the generated programs will
-eventually be run) with '--host=TYPE'.
+   For more details about configuring system types, see the Autoconf
+documentation.
 
 Sharing Defaults
 ================
 
-   If you want to set default values for 'configure' scripts to share,
-you can create a site shell script called 'config.site' that gives
-default values for variables like 'CC', 'cache_file', and 'prefix'.
-'configure' looks for 'PREFIX/share/config.site' if it exists, then
-'PREFIX/etc/config.site' if it exists.  Or, you can set the
-'CONFIG_SITE' environment variable to the location of the site script.
-A warning: not all 'configure' scripts look for a site script.
+   If you want to set default values for ‘configure’ scripts to share,
+you can create a site shell script called ‘config.site’ that gives
+default values for variables like ‘CC’, ‘cache_file’, and ‘prefix’.
+‘configure’ looks for ‘PREFIX/share/config.site’ if it exists, then
+‘PREFIX/etc/config.site’ if it exists.  Or, you can set the
+‘CONFIG_SITE’ environment variable to the location of the site script.
+A warning: not all ‘configure’ scripts look for a site script.
 
 Defining Variables
 ==================
 
    Variables not defined in a site shell script can be set in the
-environment passed to 'configure'.  However, some packages may run
+environment passed to ‘configure’.  However, some packages may run
 configure again during the build, and the customized values of these
 variables may be lost.  In order to avoid this problem, you should set
-them in the 'configure' command line, using 'VAR=value'.  For example:
+them in the ‘configure’ command line, using ‘VAR=value’.  For example:
 
      ./configure CC=/usr/local2/bin/gcc
 
-causes the specified 'gcc' to be used as the C compiler (unless it is
+causes the specified ‘gcc’ to be used as the C compiler (unless it is
 overridden in the site shell script).
 
-Unfortunately, this technique does not work for 'CONFIG_SHELL' due to an
+Unfortunately, this technique does not work for ‘CONFIG_SHELL’ due to an
 Autoconf limitation.  Until the limitation is lifted, you can use this
 workaround:
 
      CONFIG_SHELL=/bin/bash ./configure CONFIG_SHELL=/bin/bash
 
-'configure' Invocation
+‘configure’ Invocation
 ======================
 
-   'configure' recognizes the following options to control how it
+   ‘configure’ recognizes the following options to control how it
 operates.
 
-'--help'
-'-h'
-     Print a summary of all of the options to 'configure', and exit.
+‘--help’
+‘-h’
+     Print a summary of all of the options to ‘configure’, and exit.
 
-'--help=short'
-'--help=recursive'
-     Print a summary of the options unique to this package's
-     'configure', and exit.  The 'short' variant lists options used only
-     in the top level, while the 'recursive' variant lists options also
+‘--help=short’
+‘--help=recursive’
+     Print a summary of the options unique to this package’s
+     ‘configure’, and exit.  The ‘short’ variant lists options used only
+     in the top level, while the ‘recursive’ variant lists options also
      present in any nested packages.
 
-'--version'
-'-V'
-     Print the version of Autoconf used to generate the 'configure'
+‘--version’
+‘-V’
+     Print the version of Autoconf used to generate the ‘configure’
      script, and exit.
 
-'--cache-file=FILE'
+‘--cache-file=FILE’
      Enable the cache: use and save the results of the tests in FILE,
-     traditionally 'config.cache'.  FILE defaults to '/dev/null' to
+     traditionally ‘config.cache’.  FILE defaults to ‘/dev/null’ to
      disable caching.
 
-'--config-cache'
-'-C'
-     Alias for '--cache-file=config.cache'.
+‘--config-cache’
+‘-C’
+     Alias for ‘--cache-file=config.cache’.
 
-'--quiet'
-'--silent'
-'-q'
-     Do not print messages saying which checks are being made.  To
-     suppress all normal output, redirect it to '/dev/null' (any error
-     messages will still be shown).
+‘--srcdir=DIR’
+     Look for the package’s source code in directory DIR.  Usually
+     ‘configure’ can determine that directory automatically.
 
-'--srcdir=DIR'
-     Look for the package's source code in directory DIR.  Usually
-     'configure' can determine that directory automatically.
-
-'--prefix=DIR'
-     Use DIR as the installation prefix.  *note Installation Names:: for
+‘--prefix=DIR’
+     Use DIR as the installation prefix.  See “Installation Names” for
      more details, including other options available for fine-tuning the
      installation locations.
 
-'--no-create'
-'-n'
+‘--host=TYPE’
+     Build binaries for system TYPE.  See “Specifying a System Type”.
+
+‘--enable-FEATURE’
+‘--disable-FEATURE’
+     Enable or disable the optional FEATURE.  See “Optional Features”.
+
+‘--with-PACKAGE’
+‘--without-PACKAGE’
+     Use or omit PACKAGE when building.  See “Optional Features”.
+
+‘--quiet’
+‘--silent’
+‘-q’
+     Do not print messages saying which checks are being made.  To
+     suppress all normal output, redirect it to ‘/dev/null’ (any error
+     messages will still be shown).
+
+‘--no-create’
+‘-n’
      Run the configure checks, but stop before creating any output
      files.
 
-'configure' also accepts some other, not widely useful, options.  Run
-'configure --help' for more details.
+‘configure’ also recognizes several environment variables, and accepts
+some other, less widely useful, options.  Run ‘configure --help’ for
+more details.
+
+Copyright notice
+================
+
+   Copyright © 1994–1996, 1999–2002, 2004–2017, 2020–2024 Free Software
+Foundation, Inc.
+
+   Copying and distribution of this file, with or without modification,
+are permitted in any medium without royalty provided the copyright
+notice and this notice are preserved.  This file is offered as-is,
+without warranty of any kind.

--- a/devutils/rmsgwchantest.c
+++ b/devutils/rmsgwchantest.c
@@ -31,11 +31,12 @@ static char svnid[] = "$Id: chantest.c 149 2013-07-03 02:01:55Z eckertb $";
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "rms.h"
 #include "rmslib.h"
 
-main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
      channel *ch;
 

--- a/lib/fileage.c
+++ b/lib/fileage.c
@@ -45,6 +45,7 @@ static char svnid[] = "$Id: fileage.c 171 2014-10-19 10:00:22Z eckertb $";
 
 #include <sys/stat.h>
 #include <sys/time.h>
+#include <time.h>
 #include <sys/types.h>
 
 

--- a/lib/getchan.c
+++ b/lib/getchan.c
@@ -48,6 +48,8 @@ static char svnid[] = "$Id: getchan.c 149 2013-07-03 02:01:55Z eckertb $";
 
 #define BIGBUF	2048
 
+extern int varsubst(Symbol *symtab, char *cbuf, char *rbuf);
+
 static char *chanfile = XMLCHANNELFILE;
 static xmlDocPtr doc = NULL;
 static xmlNode *root = NULL;

--- a/lib/getcms.c
+++ b/lib/getcms.c
@@ -37,8 +37,9 @@ static char	svnid[] = "$Id: getcms.c 167 2014-09-30 10:27:26Z eckertb $";
 #endif
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
-
+#include <ctype.h>
 #include "rmslib.h"
 
 #define BUFSIZE	2048	/* size of buffer for reading cms host file */

--- a/lib/loadenv.c
+++ b/lib/loadenv.c
@@ -33,6 +33,7 @@ static char	svnid[] = "$Id: loadenv.c 176 2014-10-27 09:07:54Z eckertb $";
 #include <string.h>
 #include <syslog.h>
 #include <errno.h>
+#include <stdlib.h>
 
 #include "rms.h"
 #include "rmslib.h"

--- a/lib/readln.c
+++ b/lib/readln.c
@@ -33,6 +33,9 @@ static char svnid[] = "$Id";
 #endif /* lint */
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
 #include "rmslib.h"
 
 

--- a/lib/senddatagram.c
+++ b/lib/senddatagram.c
@@ -34,13 +34,11 @@ static char svnid[] = "$Id: senddatagram.c 134 2011-11-28 21:40:58Z eckertb $";
 #include <syslog.h>
 #include <errno.h>
 #include <memory.h>
-
 #include <sys/types.h>
 #include <sys/socket.h>
-
 #include <netinet/in.h>
-
 #include <netdb.h>
+#include <unistd.h>
 
 
 /***

--- a/lib/sendrf.c
+++ b/lib/sendrf.c
@@ -33,9 +33,9 @@ static char	svnid[] = "$Id: sendrf.c 118 2010-08-31 11:13:15Z eckertb $";
 #include <stdlib.h>
 #include <syslog.h>
 #include <errno.h>
-
 #include <sys/select.h>
 #include <sys/time.h>
+#include <unistd.h>
 
 #include "rmslib.h"
 

--- a/lib/set.c
+++ b/lib/set.c
@@ -54,7 +54,7 @@ static char svnid[] = "$Id: set.c 56 2008-08-06 10:40:10Z eckertb $";
  */
 int clearset(set *the_set)
 {
-     register	i;
+     register int i;
 
      for (i = 0; i < 256; i++) {
 	  the_set->set_arr[i] = 0;

--- a/lib/setcmsstat.c
+++ b/lib/setcmsstat.c
@@ -42,6 +42,7 @@ static char svnid[] = "$Id: setcmsstat.c 131 2011-11-28 19:31:57Z eckertb $";
 #include "rms.h"
 #include "rmslib.h"
 
+extern int setstatfile(char *statfile);
 
 /***
  *  setcmsstat(cmsnode)

--- a/lib/statblock.c
+++ b/lib/statblock.c
@@ -34,10 +34,11 @@ static char svnid[] = "$Id: statblock.c 109 2009-08-10 08:31:14Z eckertb $";
 #include <syslog.h>
 #include <errno.h>
 #include <memory.h>
-
 #include <sys/types.h>
 #include <sys/stat.h>
-
+#include <time.h>
+#include <unistd.h>
+ 
 #include "rms.h"
 #include "rmslib.h"
 #include "rmsshm.h"

--- a/lib/statfile.c
+++ b/lib/statfile.c
@@ -36,8 +36,8 @@ static char svnid[] = "$Id: statfile.c 64 2008-08-19 07:46:15Z eckertb $";
 #include <limits.h>
 #include <fcntl.h>
 #include <utime.h>
-
 #include <sys/types.h>
+#include <unistd.h>
 
 #include "rms.h"
 #include "rmslib.h"

--- a/lib/strtrim.c
+++ b/lib/strtrim.c
@@ -69,7 +69,7 @@ char *strtrim(char *d, char *s, char *trim_chars, int trim)
       * there)
       */
      if (trim >= 0) {
-	  register c;
+	  register char c;
 	  register char	*mark = d; /* remember where we are in dest buffer */
 
 	  /*

--- a/lib/syslogmap.c
+++ b/lib/syslogmap.c
@@ -37,7 +37,7 @@ static char svnid[] = "$Id: syslogmap.c 167 2014-09-30 10:27:26Z eckertb $";
 
 #define SYSLOG_NAMES	1
 #include <syslog.h>
-
+#include <string.h>
 #include "rmslib.h"
 
 /***

--- a/lib/var.c
+++ b/lib/var.c
@@ -39,7 +39,8 @@ static char svnid[] = "$Id: var.c 56 2008-08-06 10:40:10Z eckertb $";
 #include <limits.h>
 #include <string.h>
 #include <memory.h>
-
+#include <ctype.h>
+ 
 #include "set.h"
 #include "rmslib.h"
 #include "symbol.h"

--- a/rmsgw/rmsgw.c
+++ b/rmsgw/rmsgw.c
@@ -50,7 +50,7 @@ static char svnid[] = "$Id: rmsgw.c 176 2014-10-27 09:07:54Z eckertb $";
 char *active_configfile;
 
 extern int shm_debug;
-
+extern void sbset_gw_cms(rms_status *p, char *gwcall, char *cms_host);
 
 /***
  *  dohelp()

--- a/rmsgw_aci/rmsgw_aci.c
+++ b/rmsgw_aci/rmsgw_aci.c
@@ -57,7 +57,7 @@ char *active_configfile = NULL; /* the config file actually being used */
  * externs
  */
 extern int shm_debug;
-
+extern int setstatfile(char *statfile);
 
 /***
  *  dohelp()

--- a/rmsgw_aci/wl2k_aci.c
+++ b/rmsgw_aci/wl2k_aci.c
@@ -50,7 +50,8 @@ static char svnid[] = "$Id: wl2k_aci.c 176 2014-10-27 09:07:54Z eckertb $";
  * externs
  */
 extern char *active_configfile;
-
+extern int sendChannel(config *cfg, channel *chnl);
+extern int setstatfile(char *statfile);
 
 /*
  * structure for channel ACI statistics reporting

--- a/rmsgwmon/rmsgwmon.c
+++ b/rmsgwmon/rmsgwmon.c
@@ -69,6 +69,9 @@ static char svnid[] = "$Id: rmsgwmon.c 168 2014-09-30 23:33:51Z eckertb $";
 #endif
 
 extern rms_status *rms_stat;
+extern char *map_aci_state(ACISTATE s);
+extern char *map_gw_state(GWSTATE s);
+extern char *map_gw_comm(GWSTATE s);
 
 WINDOW	*msgwin; /* general message window */
 WINDOW	*bstatwin, *aciwin, *gwwin; /* status windows and status border win */
@@ -573,7 +576,7 @@ void gwStatRun(int interval)
 /***
  *  main()
  */
-main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
      register int	i, j;
      char		*optstr = "i:l:d";


### PR DESCRIPTION
Went to build on raspberry pi and compile kept failing on missing includes and missing extern function forward declarations. This branch fixed the compile errors. 